### PR TITLE
Add autoload configuration to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
   "require": {
     "simplesamlphp/composer-module-installer": ">=1.1.3"
   },
+  "autoload": {
+    "psr-4": {
+      "SimpleSAML\\Module\\memcookie\\": "lib/"
+    }
+  },
   "support": {
     "issues": "https://github.com/simplesamlphp/simplesamlphp-module-memcookie/issues",
     "source": "https://github.com/simplesamlphp/simplesamlphp-module-memcookie/"


### PR DESCRIPTION
When installing this module via composer before, the namespace was not properly being added to the main composer autoloader, so when requests were routed to `www/auth.php` it failed on line 20: `$amc_cf = AuthMemCookie::getInstance();` because class `AuthMemCookie` could not be found. Adding this autoload section to composer.json resolves this problem.